### PR TITLE
Version upgraded to 2.3.1

### DIFF
--- a/web3swift.podspec
+++ b/web3swift.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
     spec.frameworks = 'CoreImage'
     spec.dependency 'BigInt', '~> 5.0'
     spec.dependency 'Starscream', '~> 3.1.0'
-    spec.dependency 'CryptoSwift'
+    spec.dependency 'CryptoSwift','~> 1.3.8'
     spec.dependency 'secp256k1.c', '~> 0.1'
     spec.dependency 'PromiseKit', '~> 6.8.4'
 end


### PR DESCRIPTION
The dependency version of CryptoSwift is increased to 1.3.8, which solves the problem that Xcode 12.5 cannot run